### PR TITLE
Fix hardcoded URL in Hook-Class

### DIFF
--- a/PDFParserIntegration.Hooks.class.php
+++ b/PDFParserIntegration.Hooks.class.php
@@ -1,16 +1,18 @@
 <?php
 
+
 namespace PDFParserIntegration {
-	class Hooks
-	{
-		public static function onTemplateBuildToolbox( $baseTemplate, &$toolbox ) {
-			unset($toolbox["print"]);	
-			$toolbox["htbah-print"] = [
-				'msg'  => 'pdfparserintegration-sidebar-text',
-				'href'  => "http://howtobeahero.de:1117/?title=".urlencode($baseTemplate->getSkin()->getContext()->getTitle()),
-				'id'    => 'htbah-print',
-			];
-			return true;
-		}
-	}
+        class Hooks
+        {
+                public static function onTemplateBuildToolbox( $baseTemplate, &$toolbox ) {
+                        unset($toolbox["print"]);
+                        global $wgPDFParserURL;
+                        $toolbox["htbah-print"] = [
+                                'msg'  => 'pdfparserintegration-sidebar-text',
+                                'href'  => $wgPDFParserURL.urlencode($baseTemplate->getSkin()->getContext()->getTitle()$,
+								'id'    => 'htbah-print',
+                        ];
+                        return true;
+                }
+        }
 }

--- a/PDFParserIntegration.Hooks.class.php
+++ b/PDFParserIntegration.Hooks.class.php
@@ -10,7 +10,7 @@ namespace PDFParserIntegration {
                         $toolbox["htbah-print"] = [
                                 'msg'  => 'pdfparserintegration-sidebar-text',
                                 'href'  => $wgPDFParserURL.urlencode($baseTemplate->getSkin()->getContext()->getTitle()$,
-								'id'    => 'htbah-print',
+				'id'    => 'htbah-print',
                         ];
                         return true;
                 }

--- a/README.md
+++ b/README.md
@@ -4,3 +4,6 @@ Integrates the [PDF Parser](https://github.com/Setup007/HowToBeAHero-WikiToPdf) 
 # Installation
 * Clone this repository into a folder called `PDFParser` inside your `/extensions`-folder of your MediaWiki root-folder
 * Add `wfLoadExtension( 'PDFParser' );` to the `/LocalSettings.php`-file
+* Configure Reverseproxy for the Parser and set URL in `LocalSettings.php`
+* e.g. $wgPDFParserURL = "https://pdf.howtobeahero.de?title=";
+


### PR DESCRIPTION
I fixed the hardcoded URL in the Hook Class and changed the README to properly configure Reverse Proxy, like we did on howtobeahero.de 